### PR TITLE
🐛 Respect 'withLoading' option in 'createReducerHandlers()'

### DIFF
--- a/__tests__/entity.test.js
+++ b/__tests__/entity.test.js
@@ -1,4 +1,8 @@
-import { createLoadHandler, createDeleteHandler } from '../src'
+import {
+  createLoadHandler,
+  createDeleteHandler,
+  createReducerHandlers,
+} from '../src'
 
 import tests from './tests'
 import actions from './data/actions'
@@ -162,5 +166,23 @@ describe('Keep sorting', () => {
     )
 
     expect(nextState).toEqual(equals.entity[tests.entity.keepSorting.key])
+  })
+})
+
+describe("'createReducerHandlers' options", () => {
+  const COPY = {
+    REQUEST: 'copy/REQUEST',
+    SUCCESS: 'copy/SUCCESS',
+    FAILURE: 'copy/FAILURE',
+  }
+
+  test(tests.entity.respectWithLoadingProp.title, () => {
+    const handlers = createReducerHandlers('shifts', COPY, {
+      withLoading: false,
+    })
+
+    expect(handlers).not.toHaveProperty(COPY.REQUEST)
+    expect(handlers).not.toHaveProperty(COPY.FAILURE)
+    expect(handlers).toHaveProperty(COPY.SUCCESS)
   })
 })

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -60,6 +60,10 @@ export default {
       key: 'keepSorting',
       title: 'keep sorting from meta',
     },
+    respectWithLoadingProp: {
+      key: 'respectWithLoadingProp',
+      title: "respect 'withLoading' prop",
+    },
   },
   relations: {
     addOne: {

--- a/src/entities.js
+++ b/src/entities.js
@@ -83,17 +83,27 @@ export const createReducerHandlers = (
   const field = get(handlerOptions, 'mapToKey')
   const addKey = !field || field === type ? '' : capitalizeFirstLetter(field)
 
-  return {
-    [actionTypes.REQUEST]: state =>
-      state.merge({
+  const handlers = {
+    [actionTypes.SUCCESS]: createLoadHandler(type, handlerOptions),
+  }
+
+  const withLoading = get(handlerOptions, 'withLoading', true)
+
+  if (withLoading) {
+    handlers[actionTypes.REQUEST] = state => {
+      return state.merge({
         [`isLoading${addKey}`]: true,
         [`isLoaded${addKey}`]: false,
-      }),
-    [actionTypes.SUCCESS]: createLoadHandler(type, handlerOptions),
-    [actionTypes.FAILURE]: state =>
-      state.merge({
+      })
+    }
+
+    handlers[actionTypes.FAILURE] = state => {
+      return state.merge({
         [`isLoading${addKey}`]: false,
         [`isLoaded${addKey}`]: false,
-      }),
+      })
+    }
   }
+
+  return handlers
 }


### PR DESCRIPTION
This PR fixes `createReducerHandlers()` ignoring `withLoading` option, wich may cause infinite loader in UI